### PR TITLE
Add kitty.app to terminals that support italics

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -138,7 +138,8 @@
 let s:terms_italic=[
             \"rxvt",
             \"gnome-terminal",
-            \"iTerm.app"
+            \"iTerm.app",
+            \"kitty.app"
             \]
 " For reference only, terminals are known to be incomptible.
 " Terminals that are in neither list need to be tested.


### PR DESCRIPTION
There is a list of others [here](https://superuser.com/a/958804/885475) to possibly add later, but seeing as it's just one person's fork and not many people are using it...

I just found your fork, I'd been using solarized8 previously but it was too many changes and looked rubbish in 256 colours.

Switched to yours, but thought I'd add this one little bit.