### PR TITLE
Fix base03 in true colors and link SignColumn to LineNr

### DIFF
--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -242,7 +242,7 @@ let colors_name = "solarized"
 " neutral gray monotone palette component)
 if ((has("gui_running") || &termguicolors) && g:solarized_degrade == 0)
     let s:vmode       = "gui"
-    let s:base03      = "#586e75"
+    let s:base03      = "#002b36"
     let s:base02      = "#073642"
     let s:base01      = "#586e75"
     let s:base00      = "#657b83"
@@ -655,7 +655,7 @@ exe "hi! DiffDelete"     .s:fmt_none   .s:fg_red    .s:bg_base02
 exe "hi! DiffText"       .s:fmt_none   .s:fg_blue   .s:bg_base02 .s:sp_blue
     endif
 endif
-exe "hi! SignColumn"     .s:fmt_none   .s:fg_base0
+exe "hi! link SignColumn LineNr"
 exe "hi! Conceal"        .s:fmt_none   .s:fg_blue   .s:bg_none
 exe "hi! SpellBad"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_red
 exe "hi! SpellCap"       .s:fmt_curl   .s:fg_none   .s:bg_none    .s:sp_violet


### PR DESCRIPTION
Whilst trying to fix colors in solarized when using a truecolor terminal, I found your fork as the closest to perfect. These are the final two things I have found that needed fixing.

The signcolumn is more personal preference, but it is less visually jarring, when usually the content of the sign column is what should draw attention, not its existence in the first place. The current signcolumn is visually disjointed and draws attention even if nothing is indicated in the column.

I'm unsure how base03 issue hasn't been discovered before now. It doesn't match what solarized defines base03 as, and has some visual bugs as a result.

EDIT: A common workaround for the  base03 issue may be `let g:solarized_termtrans = 1` which skips the bg color altogether and just lets the term bg handle it. That works, but this feels a bit more correct :+1: 